### PR TITLE
Fix: parse response protocol and status

### DIFF
--- a/system/classes/Request/Client/Stream.php
+++ b/system/classes/Request/Client/Stream.php
@@ -90,7 +90,7 @@ class Stream extends External
         $http_response = array_shift($meta_data['wrapper_data']);
 
         // Fetch respone protocol and status
-        preg_match_all('/(\w+/\d\.\d) (\d{3})/', $http_response, $matches);
+        preg_match_all('/(\w+\/\d\.\d) (\d{3})/', $http_response, $matches);
 
         $protocol = $matches[1][0];
         $status = (int)$matches[2][0];


### PR DESCRIPTION
# PR Details

Fix parsing protocol and status in Request\Client\Stream.php

### Description

Added slash in regexp to escape "/"

### Related Issue

<!--- 
This project only accepts pull requests related to open issues

If suggesting a new feature or change, please discuss it in an issue first

If fixing a bug, there should be an issue describing it with steps to reproduce

Please link to the issue here
-->

### How Has This Been Tested

Tested by making requests to another site.

### Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [ ] Docs change / refactoring / dependency upgrade
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

### Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] My code follows the code style of this project.
- [ ] I have updated the documentation accordingly.
- [ ] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
